### PR TITLE
Module forRoot support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ indent_style = space
 indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
+quote_type = single
 
 [*.md]
 max_line_length = off

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules\\typescript\\lib"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "build",
+      "problemMatcher": ["$tsc"],
+      "group": { "kind": "build", "isDefault": true },
+      "label": "npm: build",
+      "detail": "ng build"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 A service library for integrate google tag manager in your angular project
 This library was generated with [Angular CLI](https://github.com/angular/angular-cli) version 7.2.0.
-For more info see this [how to install google tag manager article](https://itnext.io/how-to-add-google-tag-manager-to-an-angular-application-fc68624386e2) 
+For more info see this [how to install google tag manager article](https://itnext.io/how-to-add-google-tag-manager-to-an-angular-application-fc68624386e2)
 
 ## Getting Started
 
-After installing it you need to provide your GTM id in app.module.ts 
+After installing it you need to provide your GTM id in app.module.ts
 
 ```
     providers: [
@@ -14,6 +14,20 @@ After installing it you need to provide your GTM id in app.module.ts
         {provide: 'googleTagManagerId',  useValue: YOUR_GTM_ID}
     ],
 ```
+
+Or use the module's `forRoot` method
+
+```
+import { GoogleTagManagerModule } from 'angular-google-tag-manager';
+
+imports: [
+    ...
+    GoogleTagManagerModule.forRoot({
+      id: YOUR_GTM_ID,
+    })
+]
+```
+
 inject the gtmService in your controller
 
 ```
@@ -39,6 +53,7 @@ then you can start pushing events on your gtm
 ```
 
 if you want to recive tags without pushing events simply call the function to enable it
+
 ```
     this.gtmService.addGtmToDom();
 ```
@@ -52,7 +67,8 @@ npm i --save  angular-google-tag-manager
 ```
 
 ### Custom configuration and GTM environments
-You can pass *gtm_preview* and *gtm_auth* optional variables to your GTM by providing them in app.module.ts 
+
+You can pass _gtm_preview_ and _gtm_auth_ optional variables to your GTM by providing them in app.module.ts
 
 ```
     providers: [
@@ -63,9 +79,24 @@ You can pass *gtm_preview* and *gtm_auth* optional variables to your GTM by prov
     ],
 ```
 
+Or using `forRoot`
+
+```
+import { GoogleTagManagerModule } from 'angular-google-tag-manager';
+
+imports: [
+    ...
+    GoogleTagManagerModule.forRoot({
+      id: YOUR_GTM_ID,
+      gtm_auth: YOUR_GTM_AUTH,
+      gtm_preview: YOUR_GTM_ENV
+    })
+]
+```
+
 ## Authors
 
-* **Marco Zuccaroli** - *Initial work* - [Marco Zuccaroli](https://github.com/mzuccaroli)
+- **Marco Zuccaroli** - _Initial work_ - [Marco Zuccaroli](https://github.com/mzuccaroli)
 
 See also the list of [contributors](https://github.com/mzuccaroli/angular-google-tag-manager/graphs/contributors) who participated in this project.
 
@@ -75,4 +106,4 @@ This project is licensed under the MIT License
 
 ## Acknowledgments
 
-* Thanks to PurpleBooth for the [Readme Template](https://gist.github.com/PurpleBooth/109311bb0361f32d87a2) 
+- Thanks to PurpleBooth for the [Readme Template](https://gist.github.com/PurpleBooth/109311bb0361f32d87a2)

--- a/projects/angular-google-tag-manager/src/lib/angular-google-tag-manager.module.spec.ts
+++ b/projects/angular-google-tag-manager/src/lib/angular-google-tag-manager.module.spec.ts
@@ -23,7 +23,7 @@ describe('GoogleTagManagerModule', () => {
     ));
   });
 
-  fdescribe('with other options configured', () => {
+  describe('with other options configured', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
         imports: [

--- a/projects/angular-google-tag-manager/src/lib/angular-google-tag-manager.module.spec.ts
+++ b/projects/angular-google-tag-manager/src/lib/angular-google-tag-manager.module.spec.ts
@@ -1,0 +1,46 @@
+import { inject, TestBed } from '@angular/core/testing';
+
+import { GoogleTagManagerService } from './angular-google-tag-manager.service';
+import { GoogleTagManagerModule } from './angular-google-tag-manager.module';
+
+describe('GoogleTagManagerModule', () => {
+  describe('with just id configured', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          GoogleTagManagerModule.forRoot({
+            id: 'TEST_GTM_ID',
+          }),
+        ],
+      });
+    });
+
+    it('should create a GoogleTagManagerService', inject(
+      [GoogleTagManagerService],
+      (service: GoogleTagManagerService) => {
+        expect(service).toBeTruthy();
+      }
+    ));
+  });
+
+  fdescribe('with other options configured', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          GoogleTagManagerModule.forRoot({
+            id: 'TEST_GTM_ID',
+            gtm_auth: 'TEST_GTM_AUTH',
+            gtm_preview: 'TEST_GTM_PREVIEW',
+          }),
+        ],
+      });
+    });
+
+    it('should create a GoogleTagManagerService', inject(
+      [GoogleTagManagerService],
+      (service: GoogleTagManagerService) => {
+        expect(service).toBeTruthy();
+      }
+    ));
+  });
+});

--- a/projects/angular-google-tag-manager/src/lib/angular-google-tag-manager.module.ts
+++ b/projects/angular-google-tag-manager/src/lib/angular-google-tag-manager.module.ts
@@ -1,0 +1,12 @@
+import { NgModule, ModuleWithProviders } from '@angular/core';
+import { GoogleTagManagerConfig } from './google-tag-manager-config';
+
+@NgModule()
+export class GoogleTagManagerModule {
+  public static forRoot(config: GoogleTagManagerConfig): ModuleWithProviders {
+    return {
+      ngModule: GoogleTagManagerModule,
+      providers: [{ provide: 'googleTagManagerConfig', useValue: config }],
+    };
+  }
+}

--- a/projects/angular-google-tag-manager/src/lib/angular-google-tag-manager.service.ts
+++ b/projects/angular-google-tag-manager/src/lib/angular-google-tag-manager.service.ts
@@ -1,102 +1,113 @@
 import { Inject, Injectable, Optional } from '@angular/core';
+import { GoogleTagManagerConfig } from './google-tag-manager-config';
 
 @Injectable({
-    providedIn: 'root'
+  providedIn: 'root',
 })
 export class GoogleTagManagerService {
-    private isLoaded = false;
-    private gtmId: string;
-    private gtmAuth: string;
-    private gtmPreview: string;
+  private isLoaded = false;
 
-    private browserGlobals = {
-        windowRef(): any {
-            return window;
-        },
-        documentRef(): any {
-            return document;
-        }
+  private browserGlobals = {
+    windowRef(): any {
+      return window;
+    },
+    documentRef(): any {
+      return document;
+    },
+  };
+
+  constructor(
+    @Optional()
+    @Inject('googleTagManagerConfig')
+    public config: GoogleTagManagerConfig = { id: null },
+    @Optional() @Inject('googleTagManagerId') public googleTagManagerId: string,
+    @Optional()
+    @Inject('googleTagManagerAuth')
+    public googleTagManagerAuth: string,
+    @Optional()
+    @Inject('googleTagManagerPreview')
+    public googleTagManagerPreview: string
+  ) {
+    if (this.config == null) {
+      this.config = { id: null };
+    }
+
+    this.config = {
+      ...this.config,
+      id: googleTagManagerId || this.config.id,
+      gtm_auth: googleTagManagerAuth || this.config['gtm_auth'],
+      gtm_preview: googleTagManagerPreview || this.config['gtm_preview'],
     };
+    if (this.config.id == null) {
+      throw new Error('Google tag manager ID not provided.');
+    }
+  }
 
-    constructor(
-        @Inject('googleTagManagerId') public googleTagManagerId: string,
-        @Optional() @Inject('googleTagManagerAuth') public googleTagManagerAuth: string,
-        @Optional() @Inject('googleTagManagerPreview') public googleTagManagerPreview: string
-    ) {
-        this.gtmId = googleTagManagerId;
-        this.gtmAuth = googleTagManagerAuth;
-        this.gtmPreview = googleTagManagerPreview;
+  public getDataLayer() {
+    const window = this.browserGlobals.windowRef();
+    window['dataLayer'] = window['dataLayer'] || [];
+    return window['dataLayer'];
+  }
+
+  private pushOnDataLayer(obj: object) {
+    const dataLayer = this.getDataLayer();
+    dataLayer.push(obj);
+  }
+
+  public addGtmToDom() {
+    if (this.isLoaded) {
+      return;
+    }
+    const doc = this.browserGlobals.documentRef();
+    this.pushOnDataLayer({
+      'gtm.start': new Date().getTime(),
+      event: 'gtm.js',
+    });
+
+    const gtmScript = doc.createElement('script');
+    gtmScript.id = 'GTMscript';
+    gtmScript.async = true;
+    gtmScript.src = this.applyGtmQueryParams(
+      '//www.googletagmanager.com/gtm.js'
+    );
+    doc.head.insertBefore(gtmScript, doc.head.firstChild);
+
+    const ifrm = doc.createElement('iframe');
+    ifrm.setAttribute(
+      'src',
+      this.applyGtmQueryParams('//www.googletagmanager.com/ns.html')
+    );
+    ifrm.style.width = '0';
+    ifrm.style.height = '0';
+    ifrm.style.display = 'none';
+    ifrm.style.visibility = 'hidden';
+
+    const noscript = doc.createElement('noscript');
+    noscript.id = 'GTMiframe';
+    noscript.appendChild(ifrm);
+
+    doc.body.insertBefore(noscript, doc.body.firstChild);
+    this.isLoaded = true;
+  }
+
+  public pushTag(item: object) {
+    if (!this.isLoaded) {
+      this.addGtmToDom();
+    }
+    this.pushOnDataLayer(item);
+  }
+
+  private applyGtmQueryParams(url: string) {
+    if (url.indexOf('?') === -1) {
+      url += '?';
     }
 
-    public getDataLayer() {
-        const window = this.browserGlobals.windowRef();
-        window['dataLayer'] = window['dataLayer'] || [];
-        return window['dataLayer'];
-    }
-
-    private pushOnDataLayer(obj: object) {
-        const dataLayer = this.getDataLayer();
-        dataLayer.push(obj);
-    }
-
-    public addGtmToDom() {
-        if (this.isLoaded) {
-            return;
-        }
-        const doc = this.browserGlobals.documentRef();
-        this.pushOnDataLayer({
-            'gtm.start': new Date().getTime(),
-            event: 'gtm.js'
-        });
-
-        const gtmScript = doc.createElement('script');
-        gtmScript.id = 'GTMscript';
-        gtmScript.async = true;
-        gtmScript.src = this.applyGtmQueryParams(
-            '//www.googletagmanager.com/gtm.js'
-        );
-        doc.head.insertBefore(gtmScript, doc.head.firstChild);
-
-        const ifrm = doc.createElement('iframe');
-        ifrm.setAttribute(
-            'src',
-            this.applyGtmQueryParams('//www.googletagmanager.com/ns.html')
-        );
-        ifrm.style.width = '0';
-        ifrm.style.height = '0';
-        ifrm.style.display = 'none';
-        ifrm.style.visibility = 'hidden';
-
-        const noscript = doc.createElement('noscript');
-        noscript.id = 'GTMiframe';
-        noscript.appendChild(ifrm);
-
-        doc.body.insertBefore(noscript, doc.body.firstChild);
-        this.isLoaded = true;
-    }
-
-    public pushTag(item: object) {
-        if (!this.isLoaded) {
-            this.addGtmToDom();
-        }
-        this.pushOnDataLayer(item);
-    }
-
-    private applyGtmQueryParams(url: string) {
-        const params: string[] = [`id=${this.gtmId}`];
-
-        if (this.gtmAuth) {
-            params.push(`gtm_auth=${this.gtmAuth}`);
-        }
-
-        if (this.gtmPreview) {
-            params.push(`gtm_preview=${this.gtmPreview}`);
-        }
-
-        if (url.indexOf('?') === -1) {
-            url += '?';
-        }
-
-        return url + params.join('&');
-    }
+    return (
+      url +
+      Object.keys(this.config)
+        .filter((k) => this.config[k])
+        .map((k) => `${k}=${this.config[k]}`)
+        .join('&')
+    );
+  }
 }

--- a/projects/angular-google-tag-manager/src/lib/google-tag-manager-config.ts
+++ b/projects/angular-google-tag-manager/src/lib/google-tag-manager-config.ts
@@ -1,0 +1,6 @@
+export interface GoogleTagManagerConfig {
+  id: string;
+  gtm_auth?: string;
+  gtm_preview?: string;
+  [key: string]: string;
+}

--- a/projects/angular-google-tag-manager/src/public-api.ts
+++ b/projects/angular-google-tag-manager/src/public-api.ts
@@ -3,4 +3,5 @@
  */
 
 export * from './lib/angular-google-tag-manager.service';
-
+export * from './lib/angular-google-tag-manager.module';
+export * from './lib/google-tag-manager-config';

--- a/projects/angular-google-tag-manager/src/test.ts
+++ b/projects/angular-google-tag-manager/src/test.ts
@@ -1,12 +1,11 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
-import 'core-js/es7/reflect';
 import 'zone.js/dist/zone';
 import 'zone.js/dist/zone-testing';
 import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting
+  platformBrowserDynamicTesting,
 } from '@angular/platform-browser-dynamic/testing';
 
 declare const require: any;


### PR DESCRIPTION
This PR adds the ability to import this package via a call to `GoogleTagManagerModule.forRoot` in an application's root module imports. This permits a single import point with strongly-typed options, as demonstrated in the updated README, removing the need for multiple provider entries powered by strings. 

All prior functionality has been preserved for backward compatibility.