### PR TITLE
Force use of https

### DIFF
--- a/projects/angular-google-tag-manager/src/lib/angular-google-tag-manager.service.spec.ts
+++ b/projects/angular-google-tag-manager/src/lib/angular-google-tag-manager.service.spec.ts
@@ -49,10 +49,10 @@ describe('GoogleTagManagerService', () => {
       service.pushTag(testobject);
       const iframe = document.querySelector('body > noscript > iframe');
       expect(iframe).toBeTruthy();
-      expect(iframe.getAttribute('src')).toContain('//www.googletagmanager.com/ns.html?id=');
+      expect(iframe.getAttribute('src')).toContain('https://www.googletagmanager.com/ns.html?id=');
       const script = document.querySelector('#GTMscript');
       expect(script).toBeTruthy();
-      expect(script.getAttribute('src')).toContain('//www.googletagmanager.com/gtm.js?id=');
+      expect(script.getAttribute('src')).toContain('https://www.googletagmanager.com/gtm.js?id=');
     }));
 
   it('should be able to initialize the datalayer with some defaults values of a page',

--- a/projects/angular-google-tag-manager/src/lib/angular-google-tag-manager.service.ts
+++ b/projects/angular-google-tag-manager/src/lib/angular-google-tag-manager.service.ts
@@ -68,14 +68,14 @@ export class GoogleTagManagerService {
     gtmScript.id = 'GTMscript';
     gtmScript.async = true;
     gtmScript.src = this.applyGtmQueryParams(
-      '//www.googletagmanager.com/gtm.js'
+      'https://www.googletagmanager.com/gtm.js'
     );
     doc.head.insertBefore(gtmScript, doc.head.firstChild);
 
     const ifrm = doc.createElement('iframe');
     ifrm.setAttribute(
       'src',
-      this.applyGtmQueryParams('//www.googletagmanager.com/ns.html')
+      this.applyGtmQueryParams('https://www.googletagmanager.com/ns.html')
     );
     ifrm.style.width = '0';
     ifrm.style.height = '0';


### PR DESCRIPTION
I'm using this library in an ionic app in which the Angular app runs on `http://localhost` inside a webview. Since Android does not allow outgoing HTTP calls by default, the gtm scripts are being blocked.

Since I don't see a benefit of still using http on external sources that support https anyway, I suggest forcing the use of https to load the gtm scripts.

The [current instructions of implementing gtm](https://developers.google.com/tag-manager/quickstart) also use https explicitly.