### PR TITLE
Remove NOSCRIPT iframe (we already are in js)

### DIFF
--- a/projects/angular-google-tag-manager/src/lib/angular-google-tag-manager.service.ts
+++ b/projects/angular-google-tag-manager/src/lib/angular-google-tag-manager.service.ts
@@ -72,21 +72,6 @@ export class GoogleTagManagerService {
     );
     doc.head.insertBefore(gtmScript, doc.head.firstChild);
 
-    const ifrm = doc.createElement('iframe');
-    ifrm.setAttribute(
-      'src',
-      this.applyGtmQueryParams('https://www.googletagmanager.com/ns.html')
-    );
-    ifrm.style.width = '0';
-    ifrm.style.height = '0';
-    ifrm.style.display = 'none';
-    ifrm.style.visibility = 'hidden';
-
-    const noscript = doc.createElement('noscript');
-    noscript.id = 'GTMiframe';
-    noscript.appendChild(ifrm);
-
-    doc.body.insertBefore(noscript, doc.body.firstChild);
     this.isLoaded = true;
   }
 


### PR DESCRIPTION
There is no need to add noscript tag because :
- we already are in javascript
- noscript html code are unfortunately executed when it's added from javascript try it by yourself : https://jsfiddle.net/z64akpq7/