### PR TITLE
Adding config parameter for custom gtm.js resource path

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ You can pass _gtm_preview_ and _gtm_auth_ optional variables to your GTM by prov
         ...
         {provide: 'googleTagManagerId',  useValue: YOUR_GTM_ID},
         {provide: 'googleTagManagerAuth',  useValue: YOUR_GTM_AUTH},
-        {provide: 'googleTagManagerPreview',  useValue: YOUR_GTM_ENV}
+        {provide: 'googleTagManagerPreview',  useValue: YOUR_GTM_ENV},
+        {provide: 'googleTagManagerResourcePath',  useValue: YOUR_GTM_RESOURCE_PATH}
     ],
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-google-tag-manager",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/angular-google-tag-manager/README.md
+++ b/projects/angular-google-tag-manager/README.md
@@ -75,7 +75,8 @@ You can pass _gtm_preview_ and _gtm_auth_ optional variables to your GTM by prov
         ...
         {provide: 'googleTagManagerId',  useValue: YOUR_GTM_ID},
         {provide: 'googleTagManagerAuth',  useValue: YOUR_GTM_AUTH},
-        {provide: 'googleTagManagerPreview',  useValue: YOUR_GTM_ENV}
+        {provide: 'googleTagManagerPreview',  useValue: YOUR_GTM_ENV},
+        {provide: 'googleTagManagerResourcePath',  useValue: YOUR_GTM_RESOURCE_PATH}
     ],
 ```
 
@@ -89,7 +90,8 @@ imports: [
     GoogleTagManagerModule.forRoot({
       id: YOUR_GTM_ID,
       gtm_auth: YOUR_GTM_AUTH,
-      gtm_preview: YOUR_GTM_ENV
+      gtm_preview: YOUR_GTM_ENV,
+      gtm_resource_path: YOUR_GTM_RESOURCE_PATH
     })
 ]
 ```

--- a/projects/angular-google-tag-manager/README.md
+++ b/projects/angular-google-tag-manager/README.md
@@ -70,6 +70,9 @@ npm i --save  angular-google-tag-manager
 
 You can pass _gtm_preview_ and _gtm_auth_ optional variables to your GTM by providing them in app.module.ts
 
+In case you'll need to fetch your gtm.js resource trough a first party proxy ( so to bypass any ad-blocker interference in on the client browser ) you can use the _gtm_resource_path_ parameter.
+In that case the resource will be fetched from the specified path instead that from 'https://www.googletagmanager.com/gtm.js' (all of the other queryparams will be mantained)
+
 ```
     providers: [
         ...

--- a/projects/angular-google-tag-manager/src/lib/angular-google-tag-manager.service.ts
+++ b/projects/angular-google-tag-manager/src/lib/angular-google-tag-manager.service.ts
@@ -26,7 +26,10 @@ export class GoogleTagManagerService {
     public googleTagManagerAuth: string,
     @Optional()
     @Inject('googleTagManagerPreview')
-    public googleTagManagerPreview: string
+    public googleTagManagerPreview: string,
+    @Optional()
+    @Inject('googleTagManagerResourcePath')
+    public googleTagManagerResourcePath: string
   ) {
     if (this.config == null) {
       this.config = { id: null };
@@ -37,6 +40,7 @@ export class GoogleTagManagerService {
       id: googleTagManagerId || this.config.id,
       gtm_auth: googleTagManagerAuth || this.config.gtm_auth,
       gtm_preview: googleTagManagerPreview || this.config.gtm_preview,
+      gtm_resource_path: googleTagManagerResourcePath || this.config.gtm_resource_path
     };
     if (this.config.id == null) {
       throw new Error('Google tag manager ID not provided.');
@@ -69,7 +73,7 @@ export class GoogleTagManagerService {
       gtmScript.id = 'GTMscript';
       gtmScript.async = true;
       gtmScript.src = this.applyGtmQueryParams(
-        'https://www.googletagmanager.com/gtm.js'
+        this.config.gtm_resource_path ? this.config.gtm_resource_path : 'https://www.googletagmanager.com/gtm.js'
       );
       gtmScript.addEventListener('load', () => {
         return resolve(this.isLoaded = true);


### PR DESCRIPTION
Added configurable gtm resource path to the module config, in case you need to to retrieve the gtm.js resource via proxy to avoid common Ad-blocker software from rewriting or blocking it.