### PR TITLE
fix(google-tag-manager-config-service): initialize injection token first

### DIFF
--- a/projects/angular-google-tag-manager/src/lib/angular-google-tag-manager-config.service.ts
+++ b/projects/angular-google-tag-manager/src/lib/angular-google-tag-manager-config.service.ts
@@ -1,6 +1,9 @@
 import { Inject, Injectable, InjectionToken, Optional } from '@angular/core';
 import { GoogleTagManagerConfig } from './google-tag-manager-config';
 
+export const GoogleTagManagerConfigService =
+  new InjectionToken<GoogleTagManagerConfig>('google-tag-manager-config');
+
 // adapted from https://github.com/auth0/auth0-angular#dynamic-configuration
 @Injectable({ providedIn: 'root' })
 export class GoogleTagManagerConfiguration {
@@ -29,5 +32,3 @@ export class GoogleTagManagerConfiguration {
   }
 }
 
-export const GoogleTagManagerConfigService =
-  new InjectionToken<GoogleTagManagerConfig>('google-tag-manager-config');


### PR DESCRIPTION
Fix for #147 