### PR TITLE
Fix #171 and added "silent mode"

### DIFF
--- a/projects/angular-google-tag-manager/package.json
+++ b/projects/angular-google-tag-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-google-tag-manager",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/projects/angular-google-tag-manager/src/lib/angular-google-tag-manager.service.ts
+++ b/projects/angular-google-tag-manager/src/lib/angular-google-tag-manager.service.ts
@@ -50,9 +50,6 @@ export class GoogleTagManagerService {
       gtm_resource_path:
         googleTagManagerResourcePath || this.config.gtm_resource_path,
     };
-    if (this.config.id == null) {
-      return;
-    }
   }
 
   private checkForId(): boolean {

--- a/projects/angular-google-tag-manager/src/lib/angular-google-tag-manager.service.ts
+++ b/projects/angular-google-tag-manager/src/lib/angular-google-tag-manager.service.ts
@@ -50,6 +50,9 @@ export class GoogleTagManagerService {
       gtm_resource_path:
         googleTagManagerResourcePath || this.config.gtm_resource_path,
     };
+    if (this.config.id == null) {
+      return;
+    }
   }
 
   private checkForId(): boolean {

--- a/projects/angular-google-tag-manager/src/public-api.ts
+++ b/projects/angular-google-tag-manager/src/public-api.ts
@@ -5,3 +5,4 @@
 export * from './lib/angular-google-tag-manager.service';
 export * from './lib/angular-google-tag-manager.module';
 export * from './lib/google-tag-manager-config';
+export * from './lib/angular-google-tag-manager-config.service';


### PR DESCRIPTION
Fix #171 where the public-api was missing an export.

Added a feature my team needed that I've called "silent mode", where instead of throwing an error when the GTM id is null, it will simply return false. This is especially useful for dynamically loaded GTM ids that may not always be available or valid. It looks for an injection token "googleTagManagerMode" specified as "silent" or "noisy" (defaults to "noisy") to determine the behavior.