### PR TITLE
silent mode and #171 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ You can pass _gtm_preview_ and _gtm_auth_ optional variables to your GTM by prov
         {provide: 'googleTagManagerAuth',  useValue: YOUR_GTM_AUTH},
         {provide: 'googleTagManagerPreview',  useValue: YOUR_GTM_ENV},
         {provide: 'googleTagManagerResourcePath',  useValue: YOUR_GTM_RESOURCE_PATH},
-        {provide: 'googleTagManagerCSPNonce',  useValue: YOUR_CSP_NONCE}
+        {provide: 'googleTagManagerCSPNonce',  useValue: YOUR_CSP_NONCE},
+        {provide: 'googleTagManagerMode', useValue: "silent" | "noisy"}
     ],
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-google-tag-manager",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/projects/angular-google-tag-manager/src/public-api.ts
+++ b/projects/angular-google-tag-manager/src/public-api.ts
@@ -5,3 +5,4 @@
 export * from './lib/angular-google-tag-manager.service';
 export * from './lib/angular-google-tag-manager.module';
 export * from './lib/google-tag-manager-config';
+export * from './lib/angular-google-tag-manager-config.service';


### PR DESCRIPTION
Fix https://github.com/mzuccaroli/angular-google-tag-manager/issues/171 where the public-api was missing an export.

Added a feature my team needed that I've called "silent mode", where instead of throwing an error when the GTM id is null, it will simply return false. This is especially useful for dynamically loaded GTM ids that may not always be available or valid. It looks for an injection token "googleTagManagerMode" specified as "silent" or "noisy" (defaults to "noisy") to determine the behavior.

"Silent mode" fixes https://github.com/mzuccaroli/angular-google-tag-manager/issues/158 as well I believe.