### PR TITLE
Allow the usage of the angular nonce token

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ npm i --save  angular-google-tag-manager
 
 ### Custom configuration and GTM environments
 
-You can pass _gtm_preview_ and _gtm_auth_ optional variables to your GTM by providing them in app.module.ts
+You can provide the nonce through the Angular [`CSP_NONCE`](https://angular.io/guide/security#content-security-policy) token or by providing the `googleTagManagerCSPNonce` token.
+You can pass _gtm_preview_ and _gtm_auth_ optional variables to your GTM by providing them in app.module.ts.
 
 ```
     providers: [

--- a/projects/angular-google-tag-manager/src/lib/angular-google-tag-manager.service.ts
+++ b/projects/angular-google-tag-manager/src/lib/angular-google-tag-manager.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, Optional } from '@angular/core';
+import { CSP_NONCE, Inject, Injectable, Optional, inject } from '@angular/core';
 import { GoogleTagManagerConfiguration } from './angular-google-tag-manager-config.service';
 import { GoogleTagManagerConfig } from './google-tag-manager-config';
 
@@ -37,6 +37,10 @@ export class GoogleTagManagerService {
     @Inject('googleTagManagerCSPNonce')
     public googleTagManagerCSPNonce: string
   ) {
+    const ngCspNonce = inject(CSP_NONCE);
+    if (!googleTagManagerCSPNonce && ngCspNonce){
+      this.googleTagManagerCSPNonce = ngCspNonce;
+    }
     this.config = this.googleTagManagerConfiguration?.get();
     if (this.config == null) {
       this.config = { id: null };

--- a/projects/demo-application/src/app.config.ts
+++ b/projects/demo-application/src/app.config.ts
@@ -19,7 +19,8 @@ export const appConfig: ApplicationConfig = {
     provideRouter(routes),
     provideGoogleTagManager({
       id: 'GTM-PV8586C',
-      gtm_csp_none: 'CSP-NONCE',
+      // You can provide the nonce automically by providing the value through Angular. See: https://angular.io/guide/security#content-security-policy
+      // gtm_csp_none: 'CSP-NONCE',
       // gtm_auth: YOUR_GTM_AUTH,
       // gtm_preview: YOUR_GTM_ENV
     }),

--- a/projects/demo-application/src/index.html
+++ b/projects/demo-application/src/index.html
@@ -9,6 +9,6 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>
-  <app-root></app-root>
+  <app-root ngCspNonce="randomNonceGoesHere"></app-root>
 </body>
 </html>


### PR DESCRIPTION
Hello,

I was working on applying stricter csp rules on my project and the nonce approach came along.
The library use his own token to define a nonce and that is working well.
I would like to add the support of using the Angular CSP_NONCE token as value as well. There's no breaking change with the existing way to deal with nonce.

Thank's